### PR TITLE
Removes curly braces from podspec author definition

### DIFF
--- a/iOS-SecureEntrySDK.podspec
+++ b/iOS-SecureEntrySDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
 
   spec.author       = "TicketMaster"
 
-  spec.platform     = :ios, "9.0"
+  spec.platform     = :ios, "10.0"
 
   spec.source       = { :git => "https://github.com/ticketmaster/iOS-SecureEntrySDK.git", :tag => "#{spec.version}" }
 

--- a/iOS-SecureEntrySDK.podspec
+++ b/iOS-SecureEntrySDK.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.license      = { :type => "Apache License 2.0", :file => "LICENSE" }
 
-  spec.author       = { "TicketMaster" }
+  spec.author       = "TicketMaster"
 
   spec.platform     = :ios, "9.0"
 


### PR DESCRIPTION
Currently installation via cocoapods will fail with the following error:
```
[!] Failed to load 'iOS-SecureEntrySDK' podspec:
[!] Invalid `iOS-SecureEntrySDK.podspec` file: syntax error, unexpected '}', expecting =>.
```

This should fix the error by removing the curly braces since an email address is not provided with the name in the author definition.